### PR TITLE
Fix inverted balance bar display in ConsoleBar

### DIFF
--- a/src/maai/output.py
+++ b/src/maai/output.py
@@ -36,11 +36,13 @@ def _draw_balance_bar(value: float, length: int = 30) -> str:
     value = max(0.0, min(1.0, value))
     diff = value - 0.5
     if diff > 0:
-        right = int(diff * 2 * max_len + 0.5)
-        return ' ' * max_len + '│' + '█' * right + ' ' * (max_len - right)
-    else:
-        left = int(-diff * 2 * max_len + 0.5)
+        # value > 0.5: ch1が話す確率が高い → 左側にバー
+        left = int(diff * 2 * max_len + 0.5)
         return ' ' * (max_len - left) + '█' * left + '│' + ' ' * max_len
+    else:
+        # value < 0.5: ch2が話す確率が高い → 右側にバー
+        right = int(-diff * 2 * max_len + 0.5)
+        return ' ' * max_len + '│' + '█' * right + ' ' * (max_len - right)
 
 
 def _rms(values: Union[List[float], tuple]) -> float:


### PR DESCRIPTION
  Thank you for creating and maintaining this excellent project!

  ## Summary
  This PR fixes an issue where the balance bar visualization in ConsoleBar was displaying inverted values for `p_now` predictions.

  ## Problem
  When using ConsoleBar with `bar_type="balance"`, the visual representation of turn-taking probabilities was reversed:
  - When `p_now < 0.5` (indicating ch2/system should speak), the bar was displayed on the left side
  - When `p_now > 0.5` (indicating ch1/user should speak), the bar was displayed on the right side

  This was inconsistent with the GUI plot visualization where:
  - Yellow color represents ch1 dominance (p_now > 0.5)
  - Blue color represents ch2 dominance (p_now < 0.5)

  ### Before Fix

https://github.com/user-attachments/assets/b3b000b9-8ab9-4480-acbe-d2972741f8b6

  ### After Fix


https://github.com/user-attachments/assets/bcd255e4-46af-4e9c-b523-5a3295e2e102

 ## Changes
  Modified the `_draw_balance_bar` function in `src/maai/output.py`:
  - When `value > 0.5`: Bar now correctly displays on the left (ch1 dominant)
  - When `value < 0.5`: Bar now correctly displays on the right (ch2 dominant)

  ## Testing
  Tested with the following code to verify the fix:
  ```python
  from maai import Maai, MaaiInput, MaaiOutput

  mic = MaaiInput.Mic()
  zero = MaaiInput.Zero()

  maai = Maai(mode="vap", lang="jp", audio_ch1=mic, audio_ch2=zero)
  maai_output_bar = MaaiOutput.ConsoleBar(bar_type="balance")

  maai.start()
  while True:
      result = maai.get_result()
      maai_output_bar.update(result)