### PR TITLE
Fix Installation Error on Apple Silicon macOS environments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ Homepage = "https://github.com/MaAI-Kyoto/MaAI"
 docs = [
     "mkdocs-material",
     "mkdocstrings[python]",
-]
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "fastapi>=0.111.0",
     "huggingface-hub",
     "pyqt5==5.15.11",
-    "pyqt5-qt5==5.15.2",
+    "pyqt5-qt5==5.15.19",
     "pyqt5-sip==12.17.0",
     "pyqtgraph>=0.14.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ requires-python = ">=3.10"
 dependencies = [
     "torch>=2.6.0",
     "transformers==5.5.3",
-    "onnxruntime-gpu>=1.20.0",
+    "onnxruntime-gpu>=1.20.0; sys_platform != 'darwin'",
+    "onnxruntime>=1.20.0; sys_platform == 'darwin'",
     "numpy",
     "einops>=0.7.0",
     "soundfile",


### PR DESCRIPTION
## Description
This PR addresses the installation errors on macOS with Apple Silicon chips reported in #12. The main issues were incompatible dependencies that do not support macOS and Apple Silicon environments:
- `onnxruntime-gpu` (requires CUDA, Win/Linux only)
- `pyqt5-qt5==5.15.2` (missing Apple Silicon wheels)

## Changes
**Updated `pyproject.toml`**
- Made `onnxruntime-gpu` conditional: only install on `sys_platform != darwin`
- Changed to install `onnxruntime` (CPU version) on macOS instead
- Updated `pyqt5-qt5` to a version with Apple Silicon support (`==5.15.19`), which includes wheels for both arm64 and x86_64 architectures and is compatible with `pyqt5==5.15.11`.

## Example diff:
```toml
# Before

dependencies = [
    "torch>=2.6.0",
    "transformers==5.5.3",
    "onnxruntime-gpu>=1.20.0",
    # ⋮
    "pyqt5==5.15.11",
    "pyqt5-qt5==5.15.2",
    "pyqt5-sip==12.17.0",
    "pyqtgraph>=0.14.0",
]

# After 
dependencies = [
    "torch>=2.6.0",
    "transformers==5.5.3",
    "onnxruntime-gpu>=1.20.0; sys_platform != 'darwin'", # Added platform markers
    "onnxruntime>=1.20.0; sys_platform == 'darwin'", # Added platform markers
    # ⋮
    "pyqt5==5.15.11",
    "pyqt5-qt5==5.15.19", # Updated version to 5.15.19
    "pyqt5-sip==12.17.0",
    "pyqtgraph>=0.14.0",
]
```

## Testing
**Environment**
-  M4 MacBook Air
- macOS Tahoe 26.5.1
- Python 3.12.12
- uv 0.11.7

**Test Results**
- [x] Successfully installed via `uv add "maai @ git+https://github.com/RusCucumber/MaAI-macos.git" --rev 6dc1920c502815ad6866525363df21b0a30717c1` completes without errors
- [x] Successfully executed `example/output/vap_2wav_ConsoleBar.py`
- [ ] Backward compatibility on Windows environment
- [ ] Backward compatibility on Linux environment

## Related Issues
- #12 

## Additional Notes
- During installation on macOS, users may encounter errors related to `pyaudio` due to missing `portaudio` system dependencies. This is not a package compatibility issue and is outside the scope of this PR. However, it would be helpful to update README.md with macOS-specific installation instructions, such as pre-installing `portaudio` via Homebrew.